### PR TITLE
Update Pickcode Converter

### DIFF
--- a/static/pick-code-script.js
+++ b/static/pick-code-script.js
@@ -7,6 +7,6 @@ document.addEventListener('DOMContentLoaded', function () {
         const formattedLines = inputLines.map(line => `"${line.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`);
         const formattedOutput = `[${formattedLines.join(', ')}]`;
 
-        displayAreaPickcode.textContent = formattedOutput;
+        displayAreaPickcode.value = formattedOutput;
     });
 });

--- a/static/pick-code-styles.css
+++ b/static/pick-code-styles.css
@@ -23,7 +23,3 @@
 .clicky {
     width: 75px;
 }
-
-#display-area-pickcode {
-    color: rgb(255, 255, 255);
-}

--- a/templates/pick-code.html
+++ b/templates/pick-code.html
@@ -21,8 +21,8 @@
         <!-- Right side of the output (for displaying unformatted text) -->
         <div class="pick-output">
             <h2>Output</h2>
-            <button class="clicky" onclick="copyPickCodeOutputToClipboard()">Copy to clipboard.</button>
-            <div id="display-area-pickcode"></div>
+            <p>Copy output from here.</p>
+            <textarea id="display-area-pickcode" rows="10", cols="50"></textarea>
         </div>
     </div>
 


### PR DESCRIPTION
This pull request updates the Pickcode converter to use a `textarea` element instead of a `div` element. Doing so has a few advantages:

- Allows for copy/paste directly from the `textarea` element. Previously, the copy/paste functionality was unimplemented.
- Retains indentation provided in the input, which is helpful for Python scripts. Previously, setting the `textContent` attribute of the `div` element omitted indentation from the input.